### PR TITLE
Add game over screen

### DIFF
--- a/src/main/game/GameEngine.java
+++ b/src/main/game/GameEngine.java
@@ -105,10 +105,10 @@ public class GameEngine {
      * 게임을 종료합니다
      */
     public void endGame() {
-        gameState = GameState.RESULT;
+        boolean success = scoreManager.getScore() >= 1000;
+        gameState = success ? GameState.RESULT : GameState.GAME_OVER;
         if (audioManager != null) {
-            // 게임 결과에 따라 다른 사운드 재생
-            if (scoreManager.getScore() >= 1000) { // 성공 기준 (예시)
+            if (success) {
                 audioManager.playGameSuccessSound();
             } else {
                 audioManager.playGameOverSound();

--- a/src/main/ui/GameFrame.java
+++ b/src/main/ui/GameFrame.java
@@ -26,6 +26,7 @@ public class GameFrame extends JFrame implements KeyListener {
     private GameSelectPanel gameSelectPanel;
     private SongSelectPanel songSelectPanel;
     private ResultPanel resultPanel;
+    private GameOverPanel gameOverPanel;
     private CardLayout cardLayout;
     private JPanel mainPanel;
     private Timer gameTimer;
@@ -79,6 +80,7 @@ public class GameFrame extends JFrame implements KeyListener {
         gamePanel = new GamePanel(gameEngine);
         pausePanel = new PausePanel(this);
         resultPanel = new ResultPanel(this);
+        gameOverPanel = new GameOverPanel();
 
         // PausePanel을 GamePanel에 설정
         gamePanel.setPausePanel(pausePanel);
@@ -89,6 +91,7 @@ public class GameFrame extends JFrame implements KeyListener {
         mainPanel.add(songSelectPanel, "SONG_SELECT");
         mainPanel.add(gamePanel, "GAME");
         mainPanel.add(resultPanel, "RESULT");
+        mainPanel.add(gameOverPanel, "GAME_OVER");
 
         add(mainPanel);
 
@@ -129,6 +132,11 @@ public class GameFrame extends JFrame implements KeyListener {
                 case RESULT:
                     if (!cardLayout.toString().contains("RESULT")) {
                         showResult();
+                    }
+                    break;
+                case GAME_OVER:
+                    if (!cardLayout.toString().contains("GAME_OVER")) {
+                        showGameOver();
                     }
                     break;
             }
@@ -232,6 +240,17 @@ public class GameFrame extends JFrame implements KeyListener {
 
         resultPanel.updateResult(gameEngine.getScoreManager());
         cardLayout.show(mainPanel, "RESULT");
+        requestFocus();
+    }
+
+    /**
+     * 게임 오버 화면을 표시합니다
+     */
+    public void showGameOver() {
+        if (songSelectPanel != null) {
+            songSelectPanel.onPanelDeactivated();
+        }
+        cardLayout.show(mainPanel, "GAME_OVER");
         requestFocus();
     }
 
@@ -404,6 +423,10 @@ public class GameFrame extends JFrame implements KeyListener {
 
         // 결과 화면에서 ENTER 키로 메뉴 복귀
         else if (gameEngine.getGameState() == GameState.RESULT && keyCode == KeyEvent.VK_ENTER) {
+            returnToMenu();
+        }
+        // 게임 오버 화면에서 ENTER 키로 메뉴 복귀
+        else if (gameEngine.getGameState() == GameState.GAME_OVER && keyCode == KeyEvent.VK_ENTER) {
             returnToMenu();
         }
 

--- a/src/main/ui/GameOverPanel.java
+++ b/src/main/ui/GameOverPanel.java
@@ -1,0 +1,43 @@
+package main.ui;
+
+import main.utils.Constants;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * 게임 오버 화면을 표시하는 패널
+ */
+public class GameOverPanel extends JPanel {
+    public GameOverPanel() {
+        setPreferredSize(new Dimension(Constants.WINDOW_WIDTH, Constants.WINDOW_HEIGHT));
+        setBackground(Constants.BACKGROUND_COLOR);
+        setLayout(null);
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        g2d.setColor(new Color(0, 0, 0, 150));
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+
+        g2d.setColor(Color.RED);
+        g2d.setFont(new Font("맑은 고딕", Font.BOLD, 72));
+        String title = "GAME OVER";
+        FontMetrics fm = g2d.getFontMetrics();
+        int x = (getWidth() - fm.stringWidth(title)) / 2;
+        int y = getHeight() / 2 - fm.getHeight();
+        g2d.drawString(title, x, y);
+
+        g2d.setColor(Color.WHITE);
+        g2d.setFont(new Font("맑은 고딕", Font.PLAIN, 20));
+        String info = "ENTER 키를 눌러 메뉴로";
+        fm = g2d.getFontMetrics();
+        int infoX = (getWidth() - fm.stringWidth(info)) / 2;
+        g2d.drawString(info, infoX, y + 80);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameOverPanel` to show game over screen
- wire up `GameFrame` to display GAME_OVER state
- adjust `GameEngine.endGame` to use GAME_OVER when score is low

## Testing
- `javac -d build_tmp $(find src/main -name '*.java')` *(fails: package javazoom.jl... missing)*

------
https://chatgpt.com/codex/tasks/task_e_686face1907c832487acfd46e3cb8712